### PR TITLE
chore: 作業ブランチ作成スキル(checkout-branch)を追加

### DIFF
--- a/.claude/skills/checkout-branch/SKILL.md
+++ b/.claude/skills/checkout-branch/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: checkout-branch
+description: バージョン管理ファイル（コード・設定・ドキュメント）に変更を加える前に作業ブランチを切る。ファイル編集・新規作成の前に必ずこのスキルを実行すること。
+user-invocable: true
+allowed-tools: Bash, Read
+argument-hint: <Issue番号（省略可）> <作業の概要>
+---
+
+# 作業ブランチの作成
+
+ファイルに変更を加える前に、必ず main から作業ブランチを切る。直接 main にコミットしない。
+
+---
+
+## Step 1. 現在のブランチを確認する
+
+```bash
+git branch --show-current
+git status
+```
+
+- すでに main 以外のブランチにいる場合はこのスキルの実行は不要。そのまま作業を続ける。
+- 未コミットの変更がある場合はブランチ作成前にユーザーに確認する。
+
+## Step 2. ブランチ名を決める
+
+`$ARGUMENTS`（Issue番号・作業概要）をもとに、以下の命名規則に従ってブランチ名を決める。
+
+### 命名規則
+
+```
+<type>/<issue番号>/<kebab-case-summary>
+```
+
+Issue がない場合:
+
+```
+<type>/<kebab-case-summary>
+```
+
+| type | 用途 |
+|------|------|
+| feat | 新機能 |
+| fix | バグ修正 |
+| docs | ドキュメントのみの変更 |
+| chore | ビルド・設定・依存関係など |
+| refactor | リファクタリング |
+| test | テストの追加・修正 |
+
+### 例
+
+```
+feat/4/setup-nextjs
+fix/7/login-redirect
+docs/2/phase-0-initial-setup
+chore/add-create-edit-pr-skill
+```
+
+## Step 3. main から最新を取得してブランチを作成する
+
+```bash
+git checkout main
+git pull
+git checkout -b <ブランチ名>
+```
+
+## Step 4. ブランチ名をユーザーに報告する
+
+作成したブランチ名を報告し、作業を開始してよいことを伝える。
+
+## 制約
+
+- **禁止**: main ブランチ上でファイルを編集・コミットすること
+- **禁止**: Issue がある場合にブランチ名から Issue 番号を省略すること
+- **注意**: ブランチ作成前に `git status` で未コミット変更がないことを確認すること

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ docker compose exec app npx vitest run             # テスト
 
 ## ワークフロールール
 
+- ファイルに変更を加える前に、必ず `/checkout-branch` スキルを実行して作業ブランチを切ること（main への直接コミット禁止）
 - `docs/` または `CLAUDE.md` を編集したら、必ず `/doc-consistency` スキルを実行して他ドキュメントとの整合性をチェックすること
 - PR を作成・編集するときは必ず `/create-edit-pr` スキルを実行すること
 


### PR DESCRIPTION
## 概要

ファイル編集前に作業ブランチを切ることを強制するスキルを追加した。あわせて main のブランチ保護ルール（PR必須）を有効化した。

## 変更内容

- `.claude/skills/checkout-branch/SKILL.md` を新規追加（現在ブランチ確認→命名規則に従ったブランチ作成→報告の手順を定義）
- `CLAUDE.md` ワークフロールールの先頭に「ファイル変更前は `/checkout-branch` を実行すること」を追記
- GitHub main ブランチ保護ルール（`Require a pull request before merging`、承認0件）を有効化（API経由で設定済み）

## 関連 Issue

該当なし（軽微な設定追加）

## テスト

該当なし

## スクリーンショット

なし