### PR TITLE
chore: in-progress ワークフローをスキル・ドキュメントに追加

### DIFF
--- a/.claude/skills/checkout-branch/SKILL.md
+++ b/.claude/skills/checkout-branch/SKILL.md
@@ -64,9 +64,19 @@ git pull
 git checkout -b <ブランチ名>
 ```
 
-## Step 4. ブランチ名をユーザーに報告する
+## Step 4. Issue に着手を記録する
 
-作成したブランチ名を報告し、作業を開始してよいことを伝える。
+Issue 番号が判明している場合、以下を実行する。
+
+```bash
+gh issue edit <Issue番号> --add-label "status: in-progress" --add-assignee "@me"
+```
+
+Issue 番号が不明・Issue なしの場合はスキップする。
+
+## Step 5. ブランチ名をユーザーに報告する
+
+作成したブランチ名と、Issue への着手記録の結果を報告し、作業を開始してよいことを伝える。
 
 ## 制約
 

--- a/docs/development/11_issue-management.md
+++ b/docs/development/11_issue-management.md
@@ -108,7 +108,12 @@ MVP 後は `v1.1`, `v1.2` 等のバージョンマイルストーンに移行す
 
 1. **Issue 起票** — [07_development-phases.md](07_development-phases.md) の該当フェーズ「Issue 展開バックログ（参考）」を元に Issue を起票する
 2. **マイルストーン割り当て** — 起票した Issue を対応するマイルストーンに割り当てる
-3. **開発（1 Issue / 1 PR）** — Issue を 1 枚ずつブランチで作業し、PR 経由でマージする
+3. **開発（1 Issue / 1 PR）** — Issue を 1 枚ずつ以下の手順で作業する
+   1. Issue に自分をアサイン + `status: in-progress` を付ける（二重着手防止）
+   2. ブランチを切る（`/checkout-branch`）
+   3. 実装・コミット
+   4. PR 作成（本文に `Closes #N` を記載）
+   5. レビュー → スカッシュマージ → Issue 自動クローズ
 4. **完了定義チェック** — [07_development-phases.md](07_development-phases.md) の「完了定義」チェックリストを全て満たしたらフェーズ終了
 
 ### Epic を使う条件


### PR DESCRIPTION
## 概要

Issue 着手時に `status: in-progress` ラベルとアサインを記録するワークフローを、checkout-branch スキルとドキュメントに追加する。

## 変更内容

- **スキル**: `.claude/skills/checkout-branch/SKILL.md` に Step 4「Issue に着手を記録する」を追加
  - `gh issue edit <Issue番号> --add-label "status: in-progress" --add-assignee "@me"` を実行
  - Issue 番号が不明・Issue なしの場合はスキップ
  - 旧 Step 4 を Step 5 にリナンバー
- **ドキュメント**: `docs/development/11_issue-management.md` の開発ワークフロー手順を詳細化
  - アサイン・`status: in-progress` 付与 → ブランチ作成 → 実装 → PR 作成（`Closes #N`）→ スカッシュマージの流れを明記

## 関連 Issue

該当なし

## テスト

該当なし

## スクリーンショット

なし