### PR TITLE
chore: Dockerfile を slim イメージに変更・devcontainer パスを cbt に統一

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "cbt",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "cbt",
-  "workspaceFolder": "/app",
+  "workspaceFolder": "/cbt",
   "shutdownAction": "stopCompose",
   "postCreateCommand": "npm install",
   "customizations": {
@@ -15,7 +15,7 @@
         "anthropic.claude-code"
       ],
       "settings": {
-        "typescript.tsdk": "/app/node_modules/typescript/lib",
+        "typescript.tsdk": "/cbt/node_modules/typescript/lib",
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-slim
 
 WORKDIR /cbt
 


### PR DESCRIPTION
## 概要

DevContainer で Claude Code が bash を利用できるようにするため、Dockerfile のベースイメージを alpine から slim に変更する。あわせて devcontainer.json のワークスペースパスを `/cbt` に統一する。

## 変更内容

- `Dockerfile`: ベースイメージを `node:20-alpine` → `node:20-slim` に変更（bash 同梱のため Claude Code が動作する）
- `.devcontainer/devcontainer.json`: `workspaceFolder` および `typescript.tsdk` のパスを `/app` → `/cbt` に修正

## 関連 Issue

該当なし

## テスト

- DevContainer が正常に起動することを確認済み

## スクリーンショット

なし