### PR TITLE
chore: DevContainer を非 root ユーザーで動かし権限問題を解消

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,8 @@
   "service": "cbt",
   "workspaceFolder": "/cbt",
   "shutdownAction": "stopCompose",
+  "remoteUser": "node",
+  "updateRemoteUserUID": true,
   "postCreateCommand": "npm install",
   "customizations": {
     "vscode": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,25 @@
 FROM node:20-slim
 
-WORKDIR /cbt
+ARG USER_UID=1000
+ARG USER_GID=1000
 
-COPY package*.json ./
+# node ユーザーの UID/GID をホストに合わせる（Linux で root 所有ファイルが生成される問題を防ぐ）
+# GID 衝突時は既存グループをそのまま使う
+RUN if [ "$USER_GID" != "1000" ]; then \
+      getent group "$USER_GID" || groupmod --gid "$USER_GID" node; \
+    fi \
+    && usermod --uid "$USER_UID" --gid "$USER_GID" node \
+    && chown -R node:node /home/node
+
+WORKDIR /cbt
+RUN chown node:node /cbt
+
+COPY --chown=node:node package*.json ./
 RUN npm ci
 
-COPY . .
+COPY --chown=node:node . .
+
+USER node
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        USER_UID: "${UID:-1000}"
+        USER_GID: "${GID:-1000}"
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
## 概要

DevContainer 内のプロセスが root で動作していたため、作成されたファイルがホスト側（WSL / Linux）から編集できない権限問題を解消する。

## 変更内容

- **Dockerfile**
  - `ARG USER_UID` / `ARG USER_GID`（デフォルト 1000）を追加
  - `groupmod` / `usermod` で `node` ユーザーの UID/GID をホストに合わせる（GID 衝突時は既存グループを使用）
  - `/cbt` ディレクトリと `COPY` に `--chown=node:node` を追加
  - `USER node` で非 root 実行に変更

- **docker-compose.yml**
  - `build.args` に `USER_UID: "${UID:-1000}"` / `USER_GID: "${GID:-1000}"` を追加
  - ホスト環境の UID/GID をビルド時に渡す（未設定時は 1000 にフォールバック）

- **devcontainer.json**
  - `"remoteUser": "node"` を追加（VS Code / Claude Code が node ユーザーで動作）
  - `"updateRemoteUserUID": true` を追加（macOS など UID が異なる環境でも自動補正）

## 関連 Issue

該当なし（権限問題の恒久対応）

## テスト

- [x] `docker compose build` がエラーなしで成功する
- [x] DevContainer Rebuild 後にコンテナ内のファイルが `node` ユーザー所有になる

## スクリーンショット

なし