### PR TITLE
chore: Dockerfile の npm ci を node 権限で実行し DevContainer の起動を安定化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,6 @@
   "shutdownAction": "stopCompose",
   "remoteUser": "node",
   "updateRemoteUserUID": true,
-  "postCreateCommand": "npm install",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ WORKDIR /cbt
 RUN chown node:node /cbt
 
 COPY --chown=node:node package*.json ./
+# npm ci より前に node に切り替える（root で実行すると node_modules が root 所有になる）
 USER node
 RUN npm ci
+# node 権限で事前作成しておかないと無名ボリューム初期化時に root 所有になる（.next は .dockerignore で COPY 対象外のため）
 RUN mkdir -p /cbt/.next
 
 COPY --chown=node:node . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG USER_GID=1000
 # node ユーザーの UID/GID をホストに合わせる（Linux で root 所有ファイルが生成される問題を防ぐ）
 # GID 衝突時は既存グループをそのまま使う
 RUN if [ "$USER_GID" != "1000" ]; then \
-      getent group "$USER_GID" || groupmod --gid "$USER_GID" node; \
+    getent group "$USER_GID" || groupmod --gid "$USER_GID" node; \
     fi \
     && usermod --uid "$USER_UID" --gid "$USER_GID" node \
     && chown -R node:node /home/node
@@ -15,12 +15,10 @@ WORKDIR /cbt
 RUN chown node:node /cbt
 
 COPY --chown=node:node package*.json ./
+USER node
 RUN npm ci
+RUN mkdir -p /cbt/.next
 
 COPY --chown=node:node . .
 
-USER node
-
 EXPOSE 3000
-
-CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
       - /cbt/.next
     environment:
       - NODE_ENV=development
+    command: sleep infinity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - "3000:3000"
     volumes:
       - .:/cbt
-      - /cbt/node_modules
-      - /cbt/.next
+      - /cbt/node_modules  # bind mount から切り離して node 権限の無名ボリュームで管理
+      - /cbt/.next         # コンテナ（Linux）のバイナリを含むビルド成果物をホスト OS と分離
     environment:
       - NODE_ENV=development
     command: sleep infinity


### PR DESCRIPTION
## 概要

`RUN npm ci` が root 権限で実行されていたことで `node_modules` と `.next` の無名ボリュームが root 所有となり、DevContainer 起動後に EACCES が発生していた問題を根本修正する。

## 変更内容

- **Dockerfile**
  - `USER node` を `RUN npm ci` より前に移動（node 権限で node_modules を生成）
  - `RUN mkdir -p /cbt/.next` を追加（node 権限で事前作成し、無名ボリューム初期化時の root 所有を防止）
  - `CMD` を削除（起動コマンドは docker-compose.yml の `command` で一元管理）
  - 設計意図のインラインコメントを追加
- **docker-compose.yml**
  - `command: sleep infinity` を正式採用（応急措置から昇格）
  - 無名ボリュームにコメントを追加
- **devcontainer.json**
  - `postCreateCommand: "npm install"` を削除（Dockerfile の `RUN npm ci` で完結するため不要）

## 関連 Issue

該当なし

## テスト

該当なし（DevContainer Rebuild による動作確認は PR マージ後に実施）

## スクリーンショット

なし