### PR TITLE
fix: watch-pr スクリプトの exit code 修正

### DIFF
--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -51,7 +51,7 @@ while [ $COUNT -lt $MAX ]; do
   COUNT=$((COUNT + 1))
   sleep 30
 done
-[ $COUNT -ge $MAX ] && echo "TIMEOUT"
+if [ $COUNT -ge $MAX ]; then echo "TIMEOUT"; fi
 ```
 
 ---


### PR DESCRIPTION
## 概要

watch-pr スキルの監視スクリプトで `&&` 演算子が意図しない exit 1 を返していた問題を修正する。

## 変更内容

- `.claude/skills/watch-pr/SKILL.md` のスクリプト末尾を修正
  - `[ $COUNT -ge $MAX ] && echo "TIMEOUT"` → `if [ $COUNT -ge $MAX ]; then echo "TIMEOUT"; fi`

## 関連 Issue

該当なし

## テスト

該当なし（スクリプト終了コードのみの修正）

## スクリーンショット

なし